### PR TITLE
Allow multiple defines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ var get = function(url, cb){
 	function reqListener () {
 		cb(this.responseText);
 	}
-	
+
 	var oReq = new XMLHttpRequest();
 	oReq.onload = reqListener;
 	oReq.open("get", url, true);
@@ -100,6 +100,15 @@ asyncTest("empty variable", function(){
 		deepEqual( getAMDDeps(basics), []);
 		start();
 	});
+});
+
+asyncTest("UMD with multiple defines", function(){
+  get("umd-ish.js", function(source){
+    var load = { name: "umd-ish", source: source };
+    amdExports.processSource({}, load);
+    ok(true, "did not throw");
+    start();
+  });
 });
 
 

--- a/test/umd-ish.js
+++ b/test/umd-ish.js
@@ -1,0 +1,91 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["io"] = factory();
+	else
+		root["io"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = exports = lookup;
+
+
+	function lookup(uri, opts) {
+
+	}
+
+/***/ },
+/* 11 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module, global) {/*** IMPORTS FROM imports-loader ***/
+	var define = false;
+
+	/*! JSON v3.3.2 | http://bestiejs.github.io/json3 | Copyright 2012-2014, Kit Cambridge | http://kit.mit-license.org */
+	;(function () {
+	  // Detect the `define` function exposed by asynchronous module loaders. The
+	  // strict `define` check is necessary for compatibility with `r.js`.
+	  var isLoader = typeof define === "function" && define.amd;
+
+	  // Export for asynchronous module loaders.
+	  if (isLoader) {
+	    define(function () {
+	      return JSON3;
+	    });
+	  }
+	}).call(this);
+
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module), (function() { return this; }())))
+
+/***/ }])
+});
+;
+//# sourceMappingURL=socket.io.js.map


### PR DESCRIPTION
This allows there to be multiple defines when parsing. If a define
happens twice, instead of throwing we use the one with the smallest
closure depth.